### PR TITLE
Made first examples more similar

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ cm:
 (sprout
  (process
    for keynum in '(60 62 64 65)
-   output (new midi :time (now) :keynum keynum :duration 1)
+   output (new midi :time (now) :keynum keynum)
    wait 0.5))
 ```
 cm-utils:


### PR DESCRIPTION
This small change makes the output of the first two examples, one using PROCESS, and the other using RT-PROC with LOOP, the same as to not confuse newcomers.

This makes the output of the first two examples the same to make the README very slightly more concise.